### PR TITLE
fix:Fixing the large screen on managed teams

### DIFF
--- a/src/pages/managedTeams.html
+++ b/src/pages/managedTeams.html
@@ -71,7 +71,7 @@
     </div>
   </div>
   <div class="flex flex-col md:flex-row items-center mt-16 lg:mt-24 sm:px-14 lg:px-0">
-        <div class="flex flex-col px-5 sm:px-0 lg:px-24 gap-4 md:w-[calc(100%-240px)] lg:w-full max-w-4xl">
+        <div class="flex flex-col px-5 sm:px-0 lg:px-24 gap-4 md:w-[calc(100%-240px)] lg:w-2/3 xl:w-full max-w-4xl">
             <p class="text-primary-grey font-bold text-xl sm:text-2xl">African Team Box</p>
             <p class="text-black font-bold text-2xl sm:text-4xl">
               MVPs, QuickWins und schnelle Ergebnisse
@@ -82,7 +82,7 @@
               </p>
             </div>
           </div>
-      <div class="md:w-60 lg:w-fit"><img src="/assets/images/Logo MW.png"></div>
+      <div class="md:w-60 xl:w-fit"><img src="/assets/images/Logo MW.png"></div>
   </div>
   <div class="px-5 sm:px-14 lg:px-24">
     <div class="flex border-b-4 border-[#116355] mt-5 lg:mt-0">


### PR DESCRIPTION
# Description

In this pull request I adjusted the width of the mainbornwolff image on managed teams section

## Motivation and Context

Making the managed teams fully responsive

## How Has This Been Tested and How are your changes run?

`npm run build` : when you need the pre-defined styles
OR
`npm run watch` : when you are in development

## Screenshots (if appropriate):